### PR TITLE
Write output to out.txt

### DIFF
--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -731,7 +731,27 @@ impl TraceBuilder {
         if !self.frames.is_empty() {
             if let Some(val) = val {
                 let op = self.handle_operand(val)?;
-                self.local_map.insert(frame.callinst.unwrap(), op);
+                
+                // When we inline a function, the call instruction ID in the parent frame
+                // needs to be mapped to the return value from the inlined function.
+                // This is because in AOT IR, `%result = call func()` means the variable
+                // receiving the result (%result) has the same ID as the call instruction.
+                if let Some(callinst) = frame.callinst {
+                    // Check if this was an unresolved call with a placeholder
+                    if self.unresolved_calls.remove(&callinst).is_some() {
+                        // This was an unresolved call, replace the placeholder instruction
+                        if let Some(placeholder_op) = self.local_map.get(&callinst) {
+                            if let jit_ir::Operand::Var(placeholder_idx) = placeholder_op {
+                                // Replace the placeholder instruction with the actual return value
+                                self.jit_mod.replace_with_op(*placeholder_idx, op.clone());
+                                eprintln!("@@ Replaced placeholder at InstIdx({:?}) with actual return value", 
+                                         placeholder_idx);
+                            }
+                        }
+                    }
+                    // Map the call instruction to the actual return value
+                    self.local_map.insert(callinst, op);
+                }
             }
             Ok(())
         } else {


### PR DESCRIPTION
Implement placeholder replacement in `handle_ret` to resolve unresolved call instructions with actual return values.

Previously, placeholder constants created for unresolved calls were not being replaced, leading to them reaching the codegen phase and causing panics (e.g., "Placeholder constants should have been replaced before codegen"). This change ensures these placeholders are correctly substituted.

---
<a href="https://cursor.com/background-agent?bcId=bc-6217d3fc-9fbf-41e4-b2a6-150186806f23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6217d3fc-9fbf-41e4-b2a6-150186806f23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>