### PR TITLE
function inlining placeholders

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -516,10 +516,12 @@ impl<'a> Assemble<'a> {
             match &inst {
                 #[cfg(test)]
                 jit_ir::Inst::BlackBox(_) => (),
-                jit_ir::Inst::Const(_) | jit_ir::Inst::Copy(_) | jit_ir::Inst::Tombstone => {
+                jit_ir::Inst::Const(_)
+                | jit_ir::Inst::Copy(_)
+                | jit_ir::Inst::Tombstone
+                | jit_ir::Inst::Placeholder(_) => {
                     unreachable!();
                 }
-
                 jit_ir::Inst::BinOp(i) => self.cg_binop(iidx, i),
                 jit_ir::Inst::Param(i) => {
                     // Right now, `Param`s in the body contain dummy values, and shouldn't be

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -214,7 +214,11 @@ impl Opt {
         match self.m.inst(iidx) {
             #[cfg(test)]
             Inst::BlackBox(_) => (),
-            Inst::Const(_) | Inst::Copy(_) | Inst::Tombstone | Inst::TraceHeaderStart => {
+            Inst::Const(_)
+            | Inst::Copy(_)
+            | Inst::Tombstone
+            | Inst::TraceHeaderStart
+            | Inst::Placeholder(_) => {
                 unreachable!()
             }
             Inst::BinOp(x) => self.opt_binop(iidx, x)?,


### PR DESCRIPTION
## The Bug

When functions are inlined, there's a critical issue with handling return values:

### The Problem:
Function `luaL_getmetafield` is called and returns value %13_1
When this function is inlined, no actual call instruction is generated

The return value `%13_1` is never added to the local_map
Later instructions that try to use `%13_1` (like %14_1: i1 = eq %13_1, 0i32) fail with "local operand not found"
Why It Happens:
```
bb13:
     %13_1: i32 = call luaL_getmetafield(...)  // This call gets inlined
   bb14:
     %14_1: i1 = eq %13_1, 0i32                // This tries to use %13_1 but can't find it
```

## Placeholders:

The placeholder mechanism solves this by creating a two-stage process:
1. Placeholder Creation (when encountering the inlined call):
- Create a placeholder instruction that represents the future return value
- Add this placeholder to the local_map with the expected instruction ID

Placeholder Resolution (when the inlined function returns):
- When the actual return value is computed inside the inlined function
- Replace the placeholder with the actual value
