### PR TITLE
test ci format check

### DIFF
--- a/.github/workflows/sdci.yml
+++ b/.github/workflows/sdci.yml
@@ -2,10 +2,34 @@ on:
   pull_request:
   merge_group:
 
-# This is required to silence emails about the workflow having no jobs.
-# We simply define a dummy job that does nothing much.
 jobs:
-  dummy:
+  fmt:
+    name: Format Check
     runs-on: ubuntu-latest
     steps:
-      - run: /usr/bin/true
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-
+
+      - name: Run cargo fmt check
+        run: cargo fmt --all --check

--- a/ykrt/src/compile/j2/aot_to_hir.rs
+++ b/ykrt/src/compile/j2/aot_to_hir.rs
@@ -578,7 +578,16 @@ impl<Reg: RegT + 'static> AotToHir<Reg> {
             VarLoc::StackOff(_) => todo!(),
             VarLoc::Reg(_, _) => todo!(),
             VarLoc::Const(kind) => match kind {
-                hir::ConstKind::Double(_) => todo!(),
+                hir::ConstKind::Double(_) => {
+                    let tyidx = self.opt.push_ty(hir::Ty::Double)?;
+                    self.opt.feed_arg(
+                        hir::Const {
+                            tyidx,
+                            kind: kind.clone(),
+                        }
+                        .into(),
+                    )
+                }
                 hir::ConstKind::Float(_) => todo!(),
                 hir::ConstKind::Int(x) => {
                     let tyidx = self.opt.push_ty(hir::Ty::Int(x.bitw()))?;

--- a/ykrt/src/compile/j2/x64/deopt.rs
+++ b/ykrt/src/compile/j2/x64/deopt.rs
@@ -352,7 +352,7 @@ fn reconstruct(
                     VarLoc::StackOff(_) => todo!(),
                     VarLoc::Reg(_, _) => todo!(),
                     VarLoc::Const(kind) => match kind {
-                        ConstKind::Double(_) => todo!(),
+                        ConstKind::Double(x) => x.to_bits(),
                         ConstKind::Float(_) => todo!(),
                         ConstKind::Int(x) => x.to_zero_ext_u64().unwrap(),
                         ConstKind::Ptr(x) => u64::try_from(*x).unwrap(),

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -4972,7 +4972,7 @@ mod test {
               ; %0: ptr = arg [Reg("rax", Undefined)]
               ; %1: float = arg [Reg("xmm15", Undefined)]
               ; %2: double = arg [Reg("xmm14", Undefined)]
-              ...
+              ..~
               mov r.64.x, rax
               movsd xmm1, xmm14
               movsd xmm0, xmm15
@@ -5278,8 +5278,11 @@ mod test {
               blackbox %6
               term [%0, %1]
             ",
-            &["
+            &[r#"
               ...
+              ; %0: ptr = arg [Reg("r.64.x", Undefined)]
+              ; %1: i64 = arg [Reg("r.64.z", Undefined)]
+              mov r.64.y, r.64.z
               ; %2: ptr = dynptradd %0, %1, 1
               lea r.64._, [r.64.x+r.64.y]
               ; %3: ptr = dynptradd %0, %1, 2
@@ -5289,10 +5292,10 @@ mod test {
               ; %5: ptr = dynptradd %0, %1, 8
               lea r.64._, [r.64.x+r.64.y*8]
               ; %6: ptr = dynptradd %0, %1, 16
-              shl r.64.y, 4
-              add r.64.y, r.64.x
+              shl r.64.z, 4
+              add r.64.z, r.64.x
               ...
-            "],
+            "#],
         );
 
         // not a power of 2
@@ -5338,8 +5341,12 @@ mod test {
               blackbox %6
               term [%0, %1]
             ",
-            &["
+            &[r#"
               ...
+              ; %0: ptr = arg [Reg("r.64.y", Undefined)]
+              ; %1: i32 = arg [Reg("r.64.z", Undefined)]
+              movsxd r.64.z, r.32.z
+              mov r.64.x, r.64.z
               movsxd r.64.x, r.32.x
               ; %2: ptr = dynptradd %0, %1, 1
               lea r.64._, [r.64.y+r.64.x]
@@ -5350,10 +5357,10 @@ mod test {
               ; %5: ptr = dynptradd %0, %1, 8
               lea r.64._, [r.64.y+r.64.x*8]
               ; %6: ptr = dynptradd %0, %1, 16
-              shl r.64.x, 4
-              add r.64.x, r.64.y
+              shl r.64.z, 4
+              add r.64.z, r.64.y
               ...
-            "],
+            "#],
         );
     }
 
@@ -6147,8 +6154,8 @@ mod test {
             &[r#"
               ...
               ; %0: i32 = arg [Reg("r.64.x", Undefined)]
-              ......
               mov r.32.x, r.32.x
+              ......
               ; %1: ptr = inttoptr %0
               ...
             "#],

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1918,8 +1918,7 @@ impl<'a> Assemble<'a> {
             }
             x => {
                 // If we have an optimised clone of the function, call it.
-                let va = symbol_to_ptr(&format!("__yk_opt_{x}"))
-                    .or_else(|_| symbol_to_ptr(x))
+                let va = symbol_to_ptr(&format!("__yk_opt_{x}")).or_else(|_| symbol_to_ptr(x))
                     .map_err(|e| CompilationError::General(e.to_string()))?;
                 self.emit_call(iidx, fty, Some(va), None, &args)
             }

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -1,7 +1,6 @@
 //! Interpreter-facing API to the Yk meta-tracer.
 
 #![cfg_attr(test, feature(test))]
-#![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(int_roundings)]
 #![feature(trim_prefix_suffix)]


### PR DESCRIPTION
- **Determine the trace optimisation level in MT.**
- **j2.**
- **Add ability to disable JIT using existing YK_JITC varible.**
- **Split `RegFill` into two: `RegFill` and `RegCnstrFill`.**
- **Allow the register allocator to be queried for output fills.**
- **Implement the bare minimum to get the float.c lang_test working.**
- **Standardise on the more flexible `build_and_test` function.**
- **Introduce a `log_filter` for the register allocator tests.**
- **Only arrange fills once.**
- **Add support for `double`s in `sitofp`.**
- **Implement `fadd`.**
- **Implement `fsub`.**
- **Flatten the two "put const in register" functions.**
- **Use 32-bit instructions for 64-bit constants, if they fit.**
- **Remove incorrectly copy and pasted comment.**
- **Rethink how/when constants are put in registers.**
- **Introduce the API needed for "this constant needs a temporary register".**
- **Add support for float and double consts.**
- **Add support for calling functions with floating point args / returns.**
- **Implement `fdiv`.**
- **Add missing `fsub` tests.**
- **Implement `fmul`.**
- **Port another working lang_test.**
- **Remove shouldn't-have-been-committed comments.**
- **Allow textual input HIR to specify multiple `VLoc`s.**
- **Check that entry and exit var types match.**
- **Implement `udiv`.**
- **Implement `srem`.**
- **Add missing `udiv` codegen test.**
- **Add runtime support for callee shims.**
- **Improve documentation on __yk_trace_basicblock().**
- **Consistently prefix integer comparison things with `I`.**
- **Prefix icmp comparisons with `icmp`.**
- **Implement `fcmp`.**
- **Revert "Add runtime support for callee shims."**
- **Allocate test registers properly.**
- **Simplify copying / spilling on trace entry.**
- **Clarify what the `fill`s in `spill` / `unspill` are.**
- **Move function so that it's in the same order as in `hir_to_asm.rs`.**
- **Host `self.asm.push_inst` outside of match statements where possible.**
- **Implement `fptosi`.**
- **Port another lang_test to j2.**
- **ignore a flaky test.**
- **Arrange destination register fills after copying.**
- **Link `Or` in AOT to HIR.**
- **Implement `xor`.**
- **Implement x64 codegen for `shl`.**
- **Add missing x64 test for `lshr`.**
- **Add x64 codegen for `ashr`.**
- **Deal with the 32-bit case of `sub ..., 0`.**
- **Force a reload of callee saved registers.**
- **For signed operations, operate on 64-bit registers.**
- **A better heuristic for the size of the assembled buffer.**
- **Use a better calculation for "can this be a near call"?**
- **Only optimise `eq`.**
- **Use the `gridx` passed to the function.**
- **Implement `ctpop`.**
- **Make registering a new shadow stack thread-safe.**
- **Add codegen support for integer types and `select`.**
- **Deal with the 1..=32 bit case for imm32s.**
- **Correct the documentation for what value merging should be.**
- **Introduce a `Cast` register constraint.**
- **Implement `inttoptr` and `ptrtoint` in the x64 backend.**
- **Logical shift right must not shift in set bits.**
- **Introduce missing `icmp` prefix in HIR output.**
- **Add missing guard-icmp-load optimisation tests.**
- **Deal with a 33..=64-bit `lshr` case.**
- **Implement a 16-bit case in the icmp_guard optimisation.**
- **Add the conversion from DWARF XMM register to our x64 XMM registers.**
- **Implement more of `VarLoc::StackOff`.**
- **Remove compile-time guards.**
- **Adapt the select test for j2.**
- **Rename test.**
- **Adapt the ashr test for j2.**
- **Reorder and rename `arrange_fill`s `bitw` -> `dst_bitw`.**
- **Get early return working.**
- **Optimise `load / add / store`.**
- **Align all blocks to 16 bytes.**
- **Add missing `sitofp` HIR tests.**
- **Port `ptradd` lang_test to j2.**
- **Port `guard_consting` test to j2.**
- **Port the `thread_local_in_trace` lang_test to j2.**
- **Port the `trace_while_executing2` test to j2.**
- **Fix trace `return`s.**
- **Implement `uitofp`.**
- **Handle function pointer operands in AOT code.**
- **Use a single `dlsym` cache.**
- **Port the `funcptrarg_noir` test to j2.**
- **Implement the `i16` case of the load-add-store optimisation.**
- **Implement `sdiv`.**
- **Handle `Unimplemented` AOT instructions.**
- **Implement `smax`.**
- **Add missing `sdiv` test.**
- **Implement the 64-bit case of `shl`.**
- **Optimize x64 `or` when RHS is immediate**
- **Minor doc fixes.**
- **Implement `memcpy`.**
- **Update the `intrinsic_noinline` test.**
- **Document what `outline_until` does.**
- **Check for irregular control flow.**
- **Detect outlining running out of trace.**
- **Skip promotion data when outlining idempotent functions.**
- **Support deopting of floating point registers.**
- **Trace previous `BBlockId`s properly.**
- **Implement `smin`.**
- **Implement `floor`.**
- **Implement `memset`.**
- **Switch to accepting `Undefined` and outputting `Zeroed` when possible.**
- **Implement the variable RHS case for `and`.**
- **Implement the 64-bit size variable RHS case for `lshr`.**
- **Implement the 64 bit constant case for `or`.**
- **Implement the 64-bit variable RHS case for `or`.**
- **Switch to accepting `Undefined` and outputting `Zeroed` when possible.**
- **Implement the 64-bit variable RHS case of `shl`.**
- **Implement the 64-bit case for `xor`.**
- **`smax` and `smin` can handle all bit widths.**
- **Refactor the grammar to use a `Bool` rule.**
- **Cope with i64 constants that don't fit in an imm32.**
- **There's no need to spill `StackOff`s.**
- **Check in a couple of additional places that we're not corrupting `istates`.**
- **Reset the stack pointer at the end of side-traces properly.**
- **Note an almost-forgotten non-portable horror in `hir_to_asm`.**
- **Fix mistake with a side-traces `stack_off`.**
- **Allow deopting of 16-bit values.**
- **Deal with moving stack spills at the end of a trace.**
- **Use hex notation in more parts of trace logs.**
- **Implement `fneg`.**
- **New versions of mdbook complain about the `multilingual` flag.**
- **Implement `select` for doubles.**
- **Fix comparisons.**
- **Hack in a fix required for a block-splitting optimisation.**
- **Move `SyncSafePtr` up to the top-level.**
- **The `Compiler` trait should take `Arc<Self>`.**
- **Use a two-stage `dlsym` cache.**
- **Sync ykllvm to revert shimming.**
- **Make the executable code buffer a top-level j2 thing.**
- **Split code buffers into two.**
- **Only mark pages `WX` during code patching.**
- **Try to `mmap` memory near the interpreter and existing traces.**
- **Document the layout of traces more fully.**
- **Move functions around into a more logical order.**
- **Rename function for consistency with `sidetrace_end`.**
- **Split `body_completed` in two.**
- **Put the loop and side trace functions together.**
- **Add a test for https://github.com/ykjit/yk/pull/1944.**
- **Move the prevbb check into a more prominent position.**
- **These days we're calling these "couplers", not "connectors".**
- **Implement coupler traces.**
- **Fix incorrect extension in jitc_yk cg_udiv.**
- **Pull in a test the new `yk_indirect_inline` attribute.**
- **Make the `mmap` hint address including the length requested.**
- **Fix j2 w.r.t. the recent block-splitting change.**
- **Split the optimiser into parts that are plausibly maintainable.**
- **Fix the topological sort nodes / edges.**
- **Make `HIR` instructions `clone`able.**
- **Implement guard optimisation.**
- **Document a high-level view of how the optimiser works.**
- **This function doesn't need to be `pub`.**
- **Optimise `add`.**
- **Optimise `sub`.**
- **Borrow later in `and` to match `add` and `sub`.**
- **Optimise `icmp`.**
- **Optimise `ptradd`.**
- **Optimise `dynptradd`.**
- **Optimise `sext`.**
- **Optimise `zext`.**
- **`lshr` needs to truncate.**
- **Optimise `ashr` and `lshr`.**
- **Use a better heuristic for the initial `mmap` hint address.**
- **Light(er)weight tracing.**
- **Remove debugging code.**
- **Optimise `ptrtoint`.**
- **Optimise `trunc`.**
- **Optimise `inttoptr`.**
- **Update the block ID as we go through things.**
- **Run lang_tests and yklua benchmarks on j2 in CI.**
- **`and` with constant RHS always zero extends.**
- **Optimise `shl`.**
- **Optimise `select`.**
- **Optimise `or`.**
- **Optimise `xor`.**
- **Optimise the comparison of constant pointers.**
- **Use atomic operations for the thread tracing state.**
- **Optimise `ctpop`.**
- **Optimise `mul`.**
- **Optimise `udiv`.**
- **Inherit improved software tracing ABI.**
- **Pack the software trace recorder args into one u32.**
- **Remove guard optimism.**
- **Clarify who merges and when force pushes are acceptable.**
- **Be clearer that we'll change our mind.**
- **bors is dead.**
- **Strength reduce abs in J2**
- **Rename to `int_min_poison`.**
- **Add an explicit `int_min_poison` to the HIR parser.**
- **Generate better code for `xor` with immediates on x64.**
- **Move the top-level optimiser to only knowing about instruction equivalence.**
- **Rename `OptOutcome` variant.**
- **Rename `map_iidx` to `equiv_iidx`.**
- **Make `equiv_iidx` be `&mut self`.**
- **Allow equivalence of non-consts.**
- **Rename `map_iidxs` to the more idiomatic `map`.**
- **Rename `iter_iidxs` to `for_each_iidx`.**
- **Remove pointless `canonicalise` methods.**
- **Have `canonicalise` take `&mut self`.**
- **Use a common internal method for `feed` and `feed_void`.**
- **Make canonicalisation and rewriting of iidxs take `&mut self`.**
- **Avoid copying instructions all the time.**
- **Sync ykllvm.**
- **Don't make `equiv_iidx` take `&mut self`.**
- **Strength reduce FAdd in J2**
- **Constant fold FSub in J2**
- **Constant Fold FMul**
- **Remove `mut OptT` from places it is no longer needed.**
- **Constant fold FDiv**
- **Optimise MemCpy**
- **Guarantee that [Ty]s are not duplicated.**
- **Implement common subexpression elimination.**
- **Change `for_each_iidx` into `iter_iidxs`.**
- **Call optimised functions if they're available.**
- **Use `impl Into` to slightly reduce type inference noise.**
- **Remove commented code.**
- **Translate commented code into a runnable `assert`.**
- **Rename `opt/opt.rs` to `opt/fullopt.rs`.**
- **Fix warnings that now appear on rustc-nightly.**
- **Rename the `fullopt.rs` struct to `FullOpt`.**
- **Rework the internal optimiser API.**
- **Extend the `inst_commited` API.**
- **Add a load/store elimination pass.**
- **Pass `RegActions` as `&mut`.**
- **Fuse loops.**
- **Don't generate pointless self copies.**
- **Homogenise comment widths.**
- **Shorten to equivalent.**
- **LLVM's `memcpy` has slightly different outcomes compared to libc.**
- **Audit `zero_ext_op_for_imm32`.**
- **Implement known bits analysis**
- **Deduplicate constants in traces.**
- **Add fill to `VarLoc::Reg`.**
- **Make `VarLocs` mutable.**
- **De-`SmallVec`ify `VarLocs` with the `varlocs!` macro.**
- **Remove hwt from ykrt.**
- **Remove hwt from the test suite.**
- **Unlink hwtracer from the build.**
- **Don't snapshot the entire register allocator.**
- **s/ret/return for consistency with the HIR instruction's name.**
- **Introduce `Return` traces.**
- **Remove unused dependencies.**
- **Remove the `Ret` instruction.**
- **Return traces don't need to generate a label at the end.**
- **Zero and sign extension for known bits**
- **Remove confusing comment in known bits pass**
- **`allow_guards` is always `true` so remove it.**
- **Rename block "exit" to "terminator".**
- **Optimise ICmp in known bits analysis**
- **Rethink trace kinds.**
- **Unpin rustc.**
- **Newer rustc does not require these to be `unsafe`.**
- **Implement (Guard, Return) traces.**
- **Implement known bits bitshifts**
- **The format of semi-mangled Rust method names seems to have changed.**
- **Rename functions as per our new matrix of names.**
- **`star_return_end` is used for both ControlPoint and Guard traces.**
- **`coupler_trace_start` and `controlpoint_return_start` are identical.**
- **`coupler_trace_end` and `guard_coupler_end` are identical.**
- **Homogenise comments.**
- **Ensure the doc tests are compiled with the same ABI in testing.**
- **Move location of struct.**
- **Rename `GuardRestore` to `GuardExtra`.**
- **Rename `AsmGuardRestore` to the less confusing `AsmGuard`.**
- **Split apart `AsmGuardIdx` from `GuardExtraIdx`.**
- **Move things from `Guard` to `GuardExtra`.**
- **Document why `[Frame; 1]`.**
- **We no longer use the "restore" name scheme.**
- **Use a consistent name within a method.**
- **Catch a not-corrected `term_vars`.**
- **This method is about "term" not "exit" instructions.**
- **If near-`mmap` is not possible, `mmap` something.**
- **Add `YK_JOBS` env var.**
- **Fix Clippy warning.**
- **Make `canonicalise` take `ModLikeT`.**
- **Make `canonicalise` take `&mut T`.**
- **Use the same attribute name as other `canonicalise` functions.**
- **Add `feed_guard` to `OptT`.**
- **Introduce `PassOptInner` so we can pass around uncommitted state.**
- **Move `entry_vars` from `Guard` to `GuardExtra`.**
- **Don't allocate in `iter_iidxs`.**
- **Check abs for ArbBitInt**
- **Find symbol names for promoted constants.**
- **Flatten the variables stored in a guard's frames.**
- **Prefer a `SmallVec` of 2 frames.**
- **`DeoptFrame::vars` doesn't need an `InstId`.**
- **Convert (nameless) tuple to (named) structs.**
- **Flatten `deopt_vars` in much the same way as `GuardExtra::entry_vars`.**
- **Rename guard "entry" to "exit" variables.**
- **Implement debug strings in j2**
- **Ensure that guards are only fed in via `feed_guard`.**
- **Reorder fields.**
- **Explicitly move passes to a "commit after the pass has completed" model.**
- **Inform passes of a committed equivalence.**
- **Remove unused index type.**
- **Introduce guard `Block`s.**
- **Have HIR elements return `TyIdx`s, not `Ty`s.**
- **Break out per-instruction logging into its own function.**
- **Break out the generation of `Term` code.**
- **Move the "registers may be corrupted at the start of ControlPoint" code.**
- **Add global tracing thread counter and optimize TLS lookups.**
- **Implement known bits for guards**
- **Use a slightly less confusing field name.**
- **Guard block entries shouldn't duplicate arguments.**
- **Add Location null check at control point.**
- **Add -fno-plt flag to compiler options for tests**
- **Update yklua.**
- **`assert_matches` has moved to the top-level in nightly.**
- **Update yklua.**
- **Update yklua commit reference to the latest HEAD in buildbot script.**
- **Move and rename `AsmGuardIdx` to `CompiledTraceIdx`.**
- **Optimise `sitofp`.**
- **Update docs.**
- **Add `bin/rr_c_test` to allow `rr`ing a C test.**
- **gdb_c_test: allow specifying which rust profile to use.**
- **Document that `env-var` lines are not respected by `{rr,gdb}_c_test`.**
- **Consistently format `stack(x)`.**
- **Flag incorrect return types for `ptr`/`dynptradd` in the HIR parser.**
- **Delay the construction of guard bodies.**
- **Record "is this instruction used" as just a bool.**
- **Store `deopt_vars` as relative to the main block.**
- **Move `guard_extras` from `Mod` to `Block`.**
- **Move code into guard bodies.**
- **Use `test_stubs` to remove lots of stub functions.**
- **Enable ykllvm direct controlpoint optimisation.**
- **sync ykllvm.**
- **Add conditional promote calls optimisation.**
- **Add an explicit effects system.**
- **Fix miscompliation of dyn_ptr_add when using negative indices.**
- **Don't mix bits and bytes.**
- **Implement `bitcast`.**
- **Optimise type-punning on loads.**
- **Get the with/without peeling API in better shape.**
- **Generate code for dynptradd where elem_size is not a power of 2.**
- **Add DynPtrAdd and IntToPtr to codegen_guard_bodies().**
- **Guarantee that strength_fold canonicalises.**
- **Optimise `and` codegen in the face of sign extension.**
- **Optimise generation of i1 `select`s with one constant operand.**
- **Loop peeling.**
- **Better canonicalise `icmp`.**
- **sync ykllvm**
- **Remove BB addr map stuff.**
- **In `Block`s, elide unnused instructions when pretty printing.**
- **Only print meaningful instructions in `jit-asm` output.**
- **Remove -yk-no-fallthrough.**
- **Remove the "yk block disambiguation pass".**
- **Add JSON information about traces to output.**
- **--yk-disable-tail-call-codegen doesn't appear to be required.**
- **sync ykllvm**
- **Integrate platform trace profiler with J2 compiler.**
- **When possible move, rather than spill, values.**
- **Implement format check in GitHub Actions workflow.**
- **Test that x64 calls don't clobber registers.**
- **Dummy formatting issue.**
